### PR TITLE
Application error logging and custom JSON encoder class

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ class MyJsonRpcWebsocketConsumerTest(JsonRpcWebsocketConsumer):
 
 ```
 
+## Custom JSON encoder class
+
+```python
+from django.core.serializers.json import DjangoJSONEncoder
+
+
+class DjangoJsonRpcWebsocketConsumer(JsonRpcWebsocketConsumer):
+    json_encoder_class = DjangoJSONEncoder
+```
 
 ## Testing
 

--- a/channels_jsonrpc/jsonrpcwebsocketconsumer.py
+++ b/channels_jsonrpc/jsonrpcwebsocketconsumer.py
@@ -75,6 +75,8 @@ class JsonRpcWebsocketConsumer(WebsocketConsumer):
     errors[INTERNAL_ERROR] = "Internal Error"
     errors[GENERIC_APPLICATION_ERROR] = "Application Error"
 
+    json_encoder_class = None
+
     available_rpc_methods = dict()
 
     @classmethod
@@ -176,11 +178,11 @@ class JsonRpcWebsocketConsumer(WebsocketConsumer):
         """
         Encode the given content as JSON and send it to the client.
         """
-        super(JsonRpcWebsocketConsumer, self).send(text=json.dumps(content), close=close)
+        super(JsonRpcWebsocketConsumer, self).send(text=json.dumps(content, cls=self.json_encoder_class), close=close)
 
     @classmethod
     def group_send(cls, name, content, close=False):
-        WebsocketConsumer.group_send(name, json.dumps(content), close=close)
+        WebsocketConsumer.group_send(name, json.dumps(content, cls=cls.json_encoder_class), close=close)
 
     @classmethod
     def __process(cls, data, original_msg):

--- a/channels_jsonrpc/jsonrpcwebsocketconsumer.py
+++ b/channels_jsonrpc/jsonrpcwebsocketconsumer.py
@@ -145,6 +145,7 @@ class JsonRpcWebsocketConsumer(WebsocketConsumer):
                         except JsonRpcException as e:
                             result = e.as_dict()
                         except Exception as e:
+                            logger.exception('Application error')
                             result = self.error(data.get('id'),
                                                 self.GENERIC_APPLICATION_ERROR,
                                                 str(e),

--- a/example/django_example/consumer.py
+++ b/example/django_example/consumer.py
@@ -1,3 +1,5 @@
+from django.core.serializers.json import DjangoJSONEncoder
+
 from channels_jsonrpc import JsonRpcWebsocketConsumerTest
 # import the logging library
 import logging
@@ -52,3 +54,7 @@ def ping(fake_an_error):
         #  --> {"id":1, "jsonrpc":"2.0","method":"mymodule.rpc.ping","params":{}}
         #  <-- {"id": 1, "jsonrpc": "2.0", "result": "pong"}
         return "pong"
+
+
+class DjangoJsonRpcWebsocketConsumerTest(JsonRpcWebsocketConsumerTest):
+    json_encoder_class = DjangoJSONEncoder

--- a/example/django_example/routing.py
+++ b/example/django_example/routing.py
@@ -1,6 +1,7 @@
-from .consumer import MyJsonRpcWebsocketConsumerTest
+from .consumer import MyJsonRpcWebsocketConsumerTest, DjangoJsonRpcWebsocketConsumerTest
 
 
 channel_routing = [
-    MyJsonRpcWebsocketConsumerTest.as_route(path=r"")
+    DjangoJsonRpcWebsocketConsumerTest.as_route(path=r"^/django/$"),
+    MyJsonRpcWebsocketConsumerTest.as_route(path=r""),
 ]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-channels-jsonrpc',
-    version='1.1.2',
+    version='1.1.3',
     packages=find_packages(),
     install_requires=[
           'channels',


### PR DESCRIPTION
It is quite difficult to solve Python exceptions. Now you can use:
```python
LOGGING = {
    ...
    'loggers': {
        'channels_jsonrpc': {
            'handlers': ['console'],
            'level': 'DEBUG'
        }
    }
}
```

and use custom JSON encoder to return ``datetime`` for example:
```python
from django.core.serializers.json import DjangoJSONEncoder


class DjangoJsonRpcWebsocketConsumer(JsonRpcWebsocketConsumer):
    json_encoder_class = DjangoJSONEncoder
```