### PR TITLE
Add http handler, remove threading, rework original_message

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The Django-channels-jsonrpc is aimed to enable [JSON-RPC](http://json-rpc.org/) 
 It is aimed to be:
   - Fully integrated with Channels
   - Fully implement JSON-RPC 1 and 2 protocol
+  - Support both WebSocket and HTTP transports
   - Easy integration
 
 ## Tech
@@ -29,7 +30,7 @@ $ pip install django-channels-jsonrpc
 ## Use
 
 
-See complete exmaple [here](https://github.com/millerf/django-channels-jsonrpc/blob/master/example/django_example/), and in particular [consumer.py](https://github.com/millerf/django-channels-jsonrpc/blob/master/example/django_example/)
+See complete example [here](https://github.com/millerf/django-channels-jsonrpc/blob/master/example/django_example/), and in particular [consumer.py](https://github.com/millerf/django-channels-jsonrpc/blob/master/example/django_example/)
 
 It is intended to be used as a Websocket consumer. See [documentation](http://channels.readthedocs.io/en/stable/generics.html#websockets) except... simplier...
 
@@ -42,7 +43,7 @@ class MyJsonRpcConsumer(JsonRpcConsumer):
 
     def connect(self, message, **kwargs):
         """
-        Perform things on connection start
+        Perform things on WebSocket connection start
         """
         self.message.reply_channel.send({"accept": True})
         
@@ -51,7 +52,7 @@ class MyJsonRpcConsumer(JsonRpcConsumer):
 
     def disconnect(self, message, **kwargs):
         """
-        Perform things on connection close
+        Perform things on WebSocket connection close
         """
         print("disconnect")
         # Do stuff if needed

--- a/README.md
+++ b/README.md
@@ -33,35 +33,20 @@ See complete exmaple [here](https://github.com/millerf/django-channels-jsonrpc/b
 
 It is intended to be used as a Websocket consumer. See [documentation](http://channels.readthedocs.io/en/stable/generics.html#websockets) except... simplier...
 
-Start importing the JsonRpcWebsocketConsumer class
+Import JsonRpcConsumer class and create the consumer
 
 ```python
-from channels_jsonrpc import JsonRpcWebsocketConsumer
-```
+from channels_jsonrpc import JsonRpcConsumer
 
-And create the consumer
-
-```python
-class MyJsonRpcWebsocketConsumer(JsonRpcWebsocketConsumer):
-
-    # Set to True if you want them, else leave out
-    strict_ordering = False
-    slight_ordering = False
-
-    def connection_groups(self, **kwargs):
-        """
-        Called to return the list of groups to automatically add/remove
-        this connection to/from.
-        """
-        return ["test"]
+class MyJsonRpcConsumer(JsonRpcConsumer):
 
     def connect(self, message, **kwargs):
         """
         Perform things on connection start
         """
         self.message.reply_channel.send({"accept": True})
+        
         print("connect")
-
         # Do stuff if needed
 
     def disconnect(self, message, **kwargs):
@@ -69,29 +54,30 @@ class MyJsonRpcWebsocketConsumer(JsonRpcWebsocketConsumer):
         Perform things on connection close
         """
         print("disconnect")
-
         # Do stuff if needed
 
 ```
+JsonRpcConsumer derives from Channels WebSocketConsumer, you can read about all it's features here:
+https://channels.readthedocs.io/en/stable/generics.html#websockets
 
 Then the last step is to create the RPC methos hooks. IT is done with the decorator:
 ```python
-@MyJsonRpcWebsocketConsumer.rpc_method()
+@MyJsonRpcConsumer.rpc_method()
 ````
 
 
 Like this:
 
 ```python
-@MyJsonRpcWebsocketConsumer.rpc_method()
+@MyJsonRpcConsumer.rpc_method()
 def ping():
     return "pong"
 ```
 
 
-**MyJsonRpcWebsocketConsumer.rpc_method()** accept a *string* as a parameter to 'rename' the function
+**MyJsonRpcConsumer.rpc_method()** accept a *string* as a parameter to 'rename' the function
 ```python
-@MyJsonRpcWebsocketConsumer.rpc_method("mymodule.rpc.ping")
+@MyJsonRpcConsumer.rpc_method("mymodule.rpc.ping")
 def ping():
     return "pong"
 ```
@@ -103,7 +89,7 @@ Will now be callable with "method":"mymodule.rpc.ping" in the rpc call:
 
 RPC methods can obviously accept parameters. They also return "results" or "errors":
 ```python
-@MyJsonRpcWebsocketConsumer.rpc_method("mymodule.rpc.ping")
+@MyJsonRpcConsumer.rpc_method("mymodule.rpc.ping")
 def ping(fake_an_error):
     if fake_an_error:
         # Will return an error to the client
@@ -121,7 +107,7 @@ def ping(fake_an_error):
 The original channel message - that can contain sessions (if activated with [http_user](https://channels.readthedocs.io/en/stable/generics.html#websockets)) and other important info  can be easily accessed by having a parameter named *original_message*
 
 ```python
-MyJsonRpcWebsocketConsumerTest.rpc_method()
+MyJsonRpcConsumerTest.rpc_method()
 def json_rpc_method(param1,original_message):
     ##do something with original_message
 ```
@@ -129,7 +115,7 @@ def json_rpc_method(param1,original_message):
 Example:
 
 ```python
-class MyJsonRpcWebsocketConsumerTest(JsonRpcWebsocketConsumer):
+class MyJsonRpcConsumerTest(JsonRpcConsumer):
     # Set to True to automatically port users from HTTP cookies
     # (you don't need channel_session_user, this implies it)
     # https://channels.readthedocs.io/en/stable/generics.html#websockets
@@ -137,7 +123,7 @@ class MyJsonRpcWebsocketConsumerTest(JsonRpcWebsocketConsumer):
 
 ....
 
-@MyJsonRpcWebsocketConsumerTest.rpc_method()
+@MyJsonRpcConsumerTest.rpc_method()
     def ping(original_message):
         original_message.channel_session["test"] = True
         return "pong"
@@ -151,23 +137,23 @@ class MyJsonRpcWebsocketConsumerTest(JsonRpcWebsocketConsumer):
 from django.core.serializers.json import DjangoJSONEncoder
 
 
-class DjangoJsonRpcWebsocketConsumer(JsonRpcWebsocketConsumer):
+class DjangoJsonRpcConsumer(JsonRpcConsumer):
     json_encoder_class = DjangoJSONEncoder
 ```
 
 ## Testing
 
 
-The JsonRpcWebsocketConsumer class can be tested the same way Channels Consumers are tested.
+The JsonRpcConsumer class can be tested the same way Channels Consumers are tested.
 See [here](http://channels.readthedocs.io/en/stable/testing.html)
 
 You just need to remember to set your JsonRpcConsumer class to TEST_MODE in the test:
 
 ```python
 from channels.tests import ChannelTestCase, HttpClient
-from .consumer import MyJsonRpcWebsocketConsumer
+from .consumer import MyJsonRpcConsumer
 
-MyJsonRpcWebsocketConsumer.TEST_MODE = True
+MyJsonRpcConsumer.TEST_MODE = True
 
 
 

--- a/channels_jsonrpc/__init__.py
+++ b/channels_jsonrpc/__init__.py
@@ -1,1 +1,1 @@
-from .jsonrpcwebsocketconsumer import JsonRpcWebsocketConsumer, JsonRpcWebsocketConsumerTest, JsonRpcException
+from .jsonrpcconsumer import JsonRpcConsumer, JsonRpcConsumerTest, JsonRpcException

--- a/channels_jsonrpc/jsonrpcconsumer.py
+++ b/channels_jsonrpc/jsonrpcconsumer.py
@@ -63,6 +63,14 @@ class JsonRpcConsumer(WebsocketConsumer):
             Server error 	Reserved for implementation-defined server-errors. (@TODO)
 
     """
+    # Add http.request alogn with default websocket events
+    method_mapping = {
+        "websocket.connect": "raw_connect",
+        "websocket.receive": "raw_receive",
+        "websocket.disconnect": "raw_disconnect",
+        "http.request": "http_handler"
+    }
+
     PARSE_ERROR = -32700
     INVALID_REQUEST = -32600
     METHOD_NOT_FOUND = -32601
@@ -136,10 +144,10 @@ class JsonRpcConsumer(WebsocketConsumer):
 
         return error
 
-    def http_consumer(self, message):
+    def http_handler(self, message):
         """
         Called on HTTP request
-        :param message:  
+        :param message: (string) message received
         :return: 
         """
         # Get Django HttpRequest object from ASGI Message

--- a/example/django_example/consumer.py
+++ b/example/django_example/consumer.py
@@ -1,6 +1,6 @@
 from django.core.serializers.json import DjangoJSONEncoder
 
-from channels_jsonrpc import JsonRpcWebsocketConsumerTest
+from channels_jsonrpc import JsonRpcConsumerTest
 # import the logging library
 import logging
 
@@ -8,7 +8,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class MyJsonRpcWebsocketConsumerTest(JsonRpcWebsocketConsumerTest):
+class MyJsonRpcWebsocketConsumerTest(JsonRpcConsumerTest):
 
     # Set to True if you want them, else leave out
     strict_ordering = False
@@ -67,5 +67,5 @@ def ping(fake_an_error):
         return "pong"
 
 
-class DjangoJsonRpcWebsocketConsumerTest(JsonRpcWebsocketConsumerTest):
+class DjangoJsonRpcWebsocketConsumerTest(JsonRpcConsumerTest):
     json_encoder_class = DjangoJSONEncoder

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 tox==2.6.0
+channels
+six


### PR DESCRIPTION
Added HTTP transport handler
Added flags to rpc_method() to handle only websocket/http transports
Removed threading till it is not required in Channels architecture
Rework access to "original_message" in handlers. It should now be accesed from kwargs